### PR TITLE
Add GitHub workflow for building Skia on Android and macOS

### DIFF
--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -35,3 +35,8 @@ jobs:
         run: python3 tools/git-sync-deps
       - name: Fetch Ninja
         run: bin/fetch-ninja
+      - name: Build Skia
+        run: |
+          bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false'
+          ninja -C out/release-darwin-arm64
+          ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -33,8 +33,18 @@ jobs:
           export PATH=${PWD}/depot_tools:${PATH}
           python3 tools/git-sync-deps
           bin/fetch-ninja
-          bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false skia_use_libwebp=false'
+          bin/gn gen out/release-darwin-arm64 \
+            --args=' \
+            target_cpu="arm64" \
+            is_official_build=true \
+            is_debug=false \
+            skia_use_libwebp_decode=true \
+            skia_use_libwebp_encode=true \
+            skia_use_libwebp=false \
+            skia_use_system_libjpeg_turbo=false \
+            skia_use_system_libpng=false \
+            skia_use_system_libwebp=false \
+            '
           bin/gn args out/release-darwin-arm64 --list
-          tools/install_dependencies.sh
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -33,8 +33,7 @@ jobs:
           export PATH=${PWD}/depot_tools:${PATH}
           python3 tools/git-sync-deps
           bin/fetch-ninja
-          bin/gn gen out/release-darwin-arm64 \
-            --args=' \
+          export BUILD_ARGS=\
             target_cpu="arm64" \
             is_official_build=true \
             is_debug=false \
@@ -43,8 +42,8 @@ jobs:
             skia_use_libwebp=false \
             skia_use_system_libjpeg_turbo=false \
             skia_use_system_libpng=false \
-            skia_use_system_libwebp=false \
-            '
+            skia_use_system_libwebp=false
+          bin/gn gen out/release-darwin-arm64 --args='$BUILD_ARGS'
           bin/gn args out/release-darwin-arm64 --list
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -28,6 +28,7 @@ jobs:
           python-version: '3.x'
       - name: Set up deptool
         run: |
+          git config --global init.defaultBranch main
           git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
           echo "export PATH=\${PWD}/depot_tools:\${PATH}" >> $GITHUB_ENV
       - name: Run git-sync-deps

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -31,12 +31,10 @@ jobs:
           git config --global init.defaultBranch main
           git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
           echo "export PATH=\${PWD}/depot_tools:\${PATH}" >> $GITHUB_ENV
-      - name: Run git-sync-deps
-        run: python3 tools/git-sync-deps
-      - name: Fetch Ninja
-        run: bin/fetch-ninja
-      - name: Build Skia
+      - name: Setup deps and build skia library
         run: |
+          python3 tools/git-sync-deps
+          bin/fetch-ninja
           bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false'
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -33,6 +33,7 @@ jobs:
           export PATH=${PWD}/depot_tools:${PATH}
           python3 tools/git-sync-deps
           bin/fetch-ninja
-          bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false'
+          bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false skia_use_libwebp=false'
+          bin/gn args out/release-darwin-arm64 --list
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -7,22 +7,30 @@ on:
   pull_request:
 
 jobs:
-  build-android:
-    name: Build Skia for Android
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Bazel
-        uses: bazelbuild/setup-bazelisk@v1
-      - name: Build Skia for Android
-        run: bazel build //:skia_public --config=android_arm64 --toolchain=//:ndk_linux_arm64_toolchain_config
+  # build-android:
+  #   name: Build Skia for Android
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up Bazel
+  #       uses: bazelbuild/setup-bazelisk@v1
+  #     - name: Build Skia for Android
+  #       run: bazel build //:skia_public --config=android_arm64 --toolchain=//:ndk_linux_arm64_toolchain_config
 
   build-macos:
     name: Build Skia for macOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Bazel
-        uses: bazelbuild/setup-bazelisk@v1
-      - name: Build Skia for macOS
-        run: bazel build //:skia_public --config=macos_x86_64 --toolchain=//:mac_toolchain_config
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Set up deptool
+        run: |
+          git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
+          echo "export PATH=\${PWD}/depot_tools:\${PATH}" >> $GITHUB_ENV
+      - name: Run git-sync-deps
+        run: python3 tools/git-sync-deps
+      - name: Fetch Ninja
+        run: bin/fetch-ninja

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -30,9 +30,7 @@ jobs:
         run: |
           git config --global init.defaultBranch main
           git clone 'https://chromium.googlesource.com/chromium/tools/depot_tools.git'
-          echo "export PATH=\${PWD}/depot_tools:\${PATH}" >> $GITHUB_ENV
-      - name: Setup deps and build skia library
-        run: |
+          export PATH=${PWD}/depot_tools:${PATH}
           python3 tools/git-sync-deps
           bin/fetch-ninja
           bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false'

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -35,5 +35,6 @@ jobs:
           bin/fetch-ninja
           bin/gn gen out/release-darwin-arm64 --args='target_cpu="arm64" is_official_build=true is_debug=false skia_use_libwebp=false'
           bin/gn args out/release-darwin-arm64 --list
+          tools/install_dependencies.sh
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -1,0 +1,28 @@
+name: Build Skia for Android and macOS
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-android:
+    name: Build Skia for Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Bazel
+        uses: bazelbuild/setup-bazelisk@v1
+      - name: Build Skia for Android
+        run: bazel build //:skia_public --config=android_arm64 --toolchain=//:ndk_linux_arm64_toolchain_config
+
+  build-macos:
+    name: Build Skia for macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Bazel
+        uses: bazelbuild/setup-bazelisk@v1
+      - name: Build Skia for macOS
+        run: bazel build //:skia_public --config=macos_x86_64 --toolchain=//:mac_toolchain_config

--- a/.github/workflows/build_skia.yml
+++ b/.github/workflows/build_skia.yml
@@ -34,7 +34,7 @@ jobs:
           python3 tools/git-sync-deps
           bin/fetch-ninja
           export BUILD_ARGS=\
-            target_cpu="arm64" \
+            target_cpu=\"arm64\" \
             is_official_build=true \
             is_debug=false \
             skia_use_libwebp_decode=true \
@@ -43,7 +43,7 @@ jobs:
             skia_use_system_libjpeg_turbo=false \
             skia_use_system_libpng=false \
             skia_use_system_libwebp=false
-          bin/gn gen out/release-darwin-arm64 --args='$BUILD_ARGS'
+          bin/gn gen out/release-darwin-arm64 --args="$BUILD_ARGS"
           bin/gn args out/release-darwin-arm64 --list
           ninja -C out/release-darwin-arm64
           ls -lh out/release-darwin-arm64


### PR DESCRIPTION
Adds a new GitHub Actions workflow for building Skia for Android and macOS binaries.

- **Workflow Creation**: Introduces a `.github/workflows/build_skia.yml` file to define the GitHub Actions workflow.
- **Trigger Configuration**: Configures the workflow to trigger on push events to the main branch and on pull requests.
- **Android Build Job**: Adds a job for building Skia for Android on an Ubuntu runner, utilizing Bazel and a specific toolchain configuration for Android ARM64.
- **macOS Build Job**: Adds a separate job for building Skia for macOS on a macOS runner, also using Bazel with a configuration and toolchain tailored for macOS x86_64.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/M-CreativeLab/skia?shareId=bc81716b-09d3-49a9-b221-7c5f463b27aa).